### PR TITLE
Support for custom config groups

### DIFF
--- a/Randomizer/RandoConfigFile.cs
+++ b/Randomizer/RandoConfigFile.cs
@@ -16,6 +16,7 @@ namespace Celeste.Mod.Randomizer {
         public List<RandoConfigRoom> ASide { get; set; }
         public List<RandoConfigRoom> BSide { get; set; }
         public List<RandoConfigRoom> CSide { get; set; }
+        public string CustomGroup;
 
         public static RandoConfigFile Load(AreaData area) {
             String fullPath = "Config/" + area.GetSID() + ".rando";

--- a/Randomizer/RandoSettings.cs
+++ b/Randomizer/RandoSettings.cs
@@ -181,9 +181,11 @@ namespace Celeste.Mod.Randomizer {
 
         public void SetNormalMaps() {
             this.DisableAllMaps();
-            foreach (var key in RandoLogic.AvailableAreas) {
-                if (key.GetLevelSet() == "Celeste") {
-                    this.EnableMap(key);
+            foreach (var levelSet in RandoLogic.LevelSets) {
+                if (levelSet.name == "Celeste") {
+                    foreach (var key in levelSet.ungroupedKeys) {
+                        this.EnableMap(key);
+                    }
                 }
             }
         }


### PR DESCRIPTION
This PR adds support for grouping maps by custom groups with a CustomGroup tag in the config. The name of the tag will then appear in the level select instead of the usual "Map A", "Map B", etc. This was done by organizing levels with a LevelSet class that keeps track of groups and their keys as well as ungrouped keys instead of the previous flat list of area keys.

The main use case this enables are maps like the Spring 2020 Collab where a large number of maps are organized into a few groups (93 -> 5). This could also be tweaked a bit to allow categories like "All C-sides" if there's demand for it.

Currently custom groups display before ungrouped maps within a levelset -- having a mixed order would probably require having a metadata YAML file to group things together.

I'm pretty new to OSS contributions and mixing with other people's code so let me know if there's anything you want me to change or tweak!