### PR TITLE
Add campaign support

### DIFF
--- a/Randomizer/RandoConfigFile.cs
+++ b/Randomizer/RandoConfigFile.cs
@@ -16,6 +16,7 @@ namespace Celeste.Mod.Randomizer {
         public List<RandoConfigRoom> ASide { get; set; }
         public List<RandoConfigRoom> BSide { get; set; }
         public List<RandoConfigRoom> CSide { get; set; }
+        public string CustomGroup;
 
         public static RandoConfigFile Load(AreaData area) {
             String fullPath = "Config/" + area.GetSID() + ".rando";

--- a/Randomizer/RandoConfigFile.cs
+++ b/Randomizer/RandoConfigFile.cs
@@ -253,14 +253,11 @@ namespace Celeste.Mod.Randomizer {
         public List<string> CollectableNames = new List<string>();
         public List<RandoMetadataMusic> Music = new List<RandoMetadataMusic>();
         public List<RandoMetadataCampaign> Campaigns = new List<RandoMetadataCampaign>();
-        public RandoMetadataCampaign Campaign;
 
         public void Add(RandoMetadataFile other) {
             this.CollectableNames.AddRange(other.CollectableNames);
             this.Music.AddRange(other.Music);
-            if (other.Campaign != null) {
-                this.Campaigns.Add(other.Campaign);
-            }
+            this.Campaigns.AddRange(other.Campaigns);
         }
         
         public static RandoMetadataFile LoadAll() {

--- a/Randomizer/RandoConfigFile.cs
+++ b/Randomizer/RandoConfigFile.cs
@@ -18,7 +18,6 @@ namespace Celeste.Mod.Randomizer {
         public List<RandoConfigRoom> ASide { get; set; }
         public List<RandoConfigRoom> BSide { get; set; }
         public List<RandoConfigRoom> CSide { get; set; }
-        public string CustomGroup;
 
         public static RandoConfigFile Load(AreaData area) {
             String fullPath = "Config/" + area.GetSID() + ".rando";
@@ -253,10 +252,15 @@ namespace Celeste.Mod.Randomizer {
     public class RandoMetadataFile {
         public List<string> CollectableNames = new List<string>();
         public List<RandoMetadataMusic> Music = new List<RandoMetadataMusic>();
+        public List<RandoMetadataCampaign> Campaigns = new List<RandoMetadataCampaign>();
+        public RandoMetadataCampaign Campaign;
 
         public void Add(RandoMetadataFile other) {
             this.CollectableNames.AddRange(other.CollectableNames);
             this.Music.AddRange(other.Music);
+            if (other.Campaign != null) {
+                this.Campaigns.Add(other.Campaign);
+            }
         }
         
         public static RandoMetadataFile LoadAll() {
@@ -281,6 +285,18 @@ namespace Celeste.Mod.Randomizer {
     public class RandoMetadataMusic {
         public string Name;
         public float Weight = 1;
+    }
+
+    public class RandoMetadataCampaign
+    {
+        public string Name;
+        public List<RandoMetadataLevelSet> LevelSets;
+    }
+
+    public class RandoMetadataLevelSet
+    {
+        public string Name;
+        public string ID;
     }
 }
 

--- a/Randomizer/RandoSettings.cs
+++ b/Randomizer/RandoSettings.cs
@@ -181,12 +181,8 @@ namespace Celeste.Mod.Randomizer {
 
         public void SetNormalMaps() {
             this.DisableAllMaps();
-            foreach (var levelSet in RandoLogic.LevelSets) {
-                if (levelSet.name == "Celeste") {
-                    foreach (var key in levelSet.ungroupedKeys) {
-                        this.EnableMap(key);
-                    }
-                }
+            foreach (var key in RandoLogic.LevelSets["Celeste"]) {
+                this.EnableMap(key);
             }
         }
 

--- a/Randomizer/RandoSettings.cs
+++ b/Randomizer/RandoSettings.cs
@@ -181,9 +181,11 @@ namespace Celeste.Mod.Randomizer {
 
         public void SetNormalMaps() {
             this.DisableAllMaps();
-            foreach (var key in RandoLogic.AvailableAreas) {
-                if (key.GetLevelSet() == "Celeste") {
-                    this.EnableMap(key);
+            foreach (var levelSet in RandoLogic.LevelSets) {
+                if (levelSet.name == "Celeste") {
+                    foreach (var key in levelSet.ungroupedKeys) {
+                        this.EnableMap(key);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Replaces custom groups with campaigns, which are groupings of levelsets with one toggle per levelset. Made more sense than custom groups since the only use case for now is the collab/collab-like maps.

Campaigns are defined in the top-level metadata like so:

Campaign:
  Name: "Spring Collab 2020"
  LevelSets:
  \- Name: "Beginner Lobby"
      ID: "SpringCollab2020/1-Beginner"
  \- Name: "Intermediate Lobby"
      ID: "SpringCollab2020/2-Intermediate"
  \- Name: "Advanced Lobby"
      ID: "SpringCollab2020/3-Advanced"
  \- Name: "Expert Lobby"
      ID: "SpringCollab2020/4-Expert"
  \- Name: "Grandmaster Lobby"
      ID: "SpringCollab2020/5-Grandmaster"

Toggling/resetting/campaigns from multiple mods were tested and work as expected. 