### PR TITLE
3a softlock fixes

### DIFF
--- a/Randomizer/Config/Celeste/3-CelestialResort.rando.yaml
+++ b/Randomizer/Config/Celeste/3-CelestialResort.rando.yaml
@@ -1075,7 +1075,7 @@ ASide:
     - Side: Up
       Idx: 0
       Kind: inout
-      ReqOut:
+      ReqBoth:
         Flag: towels:set
     - Side: Up
       Idx: 1
@@ -1554,10 +1554,7 @@ ASide:
       Idx: 0
       Kind: inout
       ReqOut:
-        Or:
-        - Dashes: one
-        - Dashes: zero
-          Difficulty: hard
+        Dashes: one
     - Side: Right
       Idx: 0
       Kind: inout


### PR DESCRIPTION
Towels switch will freeze game if enter Up:0 with towel flag unset

Presidential suite softlocks if you retry/leave room from ceiling entrance with 0-dash because of the added dash block... could also solve by removing dash block