### PR TITLE
fix 2 softlocks and add room that arti forgot

### DIFF
--- a/Randomizer/Config/Celeste/4-GoldenRidge.rando.yaml
+++ b/Randomizer/Config/Celeste/4-GoldenRidge.rando.yaml
@@ -1017,12 +1017,6 @@ ASide:
       - Side: Left
         Idx: 0
         Kind: inout
-    Subrooms:
-    - Room: "Bottom"
-      Holes:
-      - Side: Down
-        Idx: 0
-        Kind: inout
     Tweaks:
     - Name: "spawn"
       Update:

--- a/Randomizer/Config/Celeste/4-GoldenRidge.rando.yaml
+++ b/Randomizer/Config/Celeste/4-GoldenRidge.rando.yaml
@@ -999,18 +999,24 @@ ASide:
           cameraY: 0.5
   - Room: "c-06"
     Holes:
-    - Side: Up
+    - Side: Down
       Idx: 0
-      Kind: inout
-    - Side: Left
-      Idx: 0
-      Kind: inout
+      Kind: inout    
     InternalEdges:
-    - To: "Bottom"
+    - To: "Top"
       ReqOut:
-        Dashes: zero
-      ReqIn:
         Dashes: one
+      ReqIn:
+        Dashes: zero
+    Subrooms:
+    - Room: "Top"
+      Holes:
+      - Side: Up
+        Idx: 0
+        Kind: inout
+      - Side: Left
+        Idx: 0
+        Kind: inout
     Subrooms:
     - Room: "Bottom"
       Holes:

--- a/Randomizer/Config/Celeste/5-MirrorTemple.rando.yaml
+++ b/Randomizer/Config/Celeste/5-MirrorTemple.rando.yaml
@@ -618,6 +618,7 @@ ASide:
       - Idx: 0
         ReqIn:
           Dashes: zero
+          Difficulty: master
         ReqOut:
           Or:
           - Dashes: two

--- a/Randomizer/Config/Celeste/5-MirrorTemple.rando.yaml
+++ b/Randomizer/Config/Celeste/5-MirrorTemple.rando.yaml
@@ -594,20 +594,36 @@ ASide:
     - To: "top"
       ReqIn:
         Dashes: zero
+      ReqOut:
+        Or:
+        - Dashes: two
+          Diffculty: expert
+        - Dashes: one
+          Difficulty: perfect
     Subrooms:
     - Room: "top"
       Holes:
       - Side: Right
         Idx: 0
         Kind: inout
+        ReqOut:
+          Dashes: two
+          Difficulty: perfect
         ReqIn:
           Or:
-          - Dashes: one
+          - Dashes: one 
           - Dashes: zero
             Difficulty: master
       Collectables:
       - Idx: 0
-      # TODO there is no way to represent that this collectable can be gotten from the bottom with two dashes without the generator thinking that you can also get to the top of the room with two dashes
+        ReqIn:
+          Dashes: zero
+        ReqOut:
+          Or:
+          - Dashes: two
+            Diffculty: expert
+          - Dashes: one
+            Difficulty: perfect
   - Room: "b-05"
     Holes:
     - Side: Left

--- a/Randomizer/Config/Celeste/7-Summit.rando.yaml
+++ b/Randomizer/Config/Celeste/7-Summit.rando.yaml
@@ -2057,28 +2057,28 @@ ASide:
           cameraY: 0
   - Room: "e-03"
     Holes:
-    - Side: Right
-      Idx: 0
-      Kind: inout
     - Side: Left
-      Idx: 0
+      Idx: 1
       Kind: inout
     InternalEdges:
-    - To: "bottom"
-      ReqIn:
+    - To: "Top"
+      ReqOut:
         Or:
         - Dashes: two
         - Dashes: one
           Difficulty: hard
-      ReqOut:
+      ReqIn:
         Dashes: two
         Difficulty: hard
     Subrooms:
-    - Room: "bottom"
+    - Room: "Top"
       Holes:
-      - Side: Left
-        Idx: 1
-        Kind: inout
+        - Side: Right
+          Idx: 0
+          Kind: inout
+        - Side: Left
+          Idx: 0
+          Kind: inout
     Tweaks:
     - Name: "exitBlock"
       ID: 265
@@ -3182,6 +3182,18 @@ ASide:
     - Side: Up
       Idx: 0
       Kind: inout
+      LowBound: 13
+      HighBound: 17
+      ReqOut:
+        Or:
+        - Dashes: one
+        - Dashes: zero
+          Difficulty: master
+    - Side: Up
+      New: true
+      Kind: inout
+      LowBound: 30
+      HighBound: 34
       ReqOut:
         Or:
         - Dashes: one


### PR DESCRIPTION
fixed softlocks by making the main subrooms and spawn locations be the same place so that you can't get impossible exits in these rooms
added 5a b-04 collectible 1x perfect
added 5a b-04 top exit 2x perfect

(for the 4a fix use most recent as i mistakenly didn't remove the other subroom when pasting this to github)