### PR TITLE
newrooms and fixes

### DIFF
--- a/Randomizer/Config/Celeste/3-CelestialResort.rando.yaml
+++ b/Randomizer/Config/Celeste/3-CelestialResort.rando.yaml
@@ -74,6 +74,7 @@ ASide:
     - Collectable: 0
       ReqBoth:
         Dashes: one
+        Difficulty: hard
     Tweaks:
     - Name: "cameraOffsetTrigger"
       Update:
@@ -1536,7 +1537,7 @@ ASide:
         - Dashes: zero
           Difficulty: hard
         - Dashes: one
-          Dificulty: normal
+          Difficulty: normal
         - Dashes: two
           Difficulty: easy
     Holes:
@@ -1696,7 +1697,7 @@ ASide:
         Or:
         - Dashes: one
         - Dashes: zero
-          Dificulty: expert
+          Difficulty: expert
       ReqIn:
         Or:
         - Dashes: two

--- a/Randomizer/Config/Celeste/4-GoldenRidge.rando.yaml
+++ b/Randomizer/Config/Celeste/4-GoldenRidge.rando.yaml
@@ -208,7 +208,7 @@ ASide:
       Kind: None
     - Side: Down
       Idx: 0
-      Kind: None
+    - Kind: None
       Side: Right
       Idx: 0
       Kind: None
@@ -1514,7 +1514,7 @@ ASide:
       ReqOut:
           Dashes: one
       ReqIn:
-        0r:
+        Or:
         - Dashes: one
         - Dashes: zero
           Difficulty: expert
@@ -2154,20 +2154,28 @@ BSide:
           cameraY: 0
   - Room: "d-03"
     Holes:
-    - Side: Right
-      Idx: 0
-      Kind: out
-      ReqOut:
-        Dashes: one
     - Side: Left
       Idx: 0
-      Kind: in
+      Kind: inout
     - Side: Down
       Idx: 3
       Kind: None
     - Side: Down
       Idx: 2
       Kind: None
+    InternalEdges:
+    - To: "right"
+      ReqOut:
+        Dashes: one
+      ReqIn:
+        Dashes: two
+        Difficulty: perfect
+    Subrooms:
+    - Room: "right"
+      Holes:
+      - Side: Right
+        Idx: 0
+        Kind: inout
   - Room: "end"
     ReqEnd:
       Dashes: one

--- a/Randomizer/Config/Celeste/5-MirrorTemple.rando.yaml
+++ b/Randomizer/Config/Celeste/5-MirrorTemple.rando.yaml
@@ -1821,9 +1821,6 @@ BSide:
         Difficulty: perfect
   - Room: "a-02"
     Holes:
-    - Side: Up
-      Idx: 0
-      Kind: inout
     - Side: Left
       Idx: 0
       Kind: inout

--- a/Randomizer/Config/Celeste/5-MirrorTemple.rando.yaml
+++ b/Randomizer/Config/Celeste/5-MirrorTemple.rando.yaml
@@ -713,6 +713,7 @@ ASide:
       ReqOut:
         Or:
         - Dashes: one
+          Difficulty: hard
         - Dashes: zero
           Difficulty: hard
     - Side: Left

--- a/Randomizer/Config/Celeste/5-MirrorTemple.rando.yaml
+++ b/Randomizer/Config/Celeste/5-MirrorTemple.rando.yaml
@@ -614,17 +614,17 @@ ASide:
           - Dashes: one 
           - Dashes: zero
             Difficulty: master
-      Collectables:
-      - Idx: 0
+      InternalEdges:
+      - Collectable: 0
         ReqIn:
           Dashes: zero
           Difficulty: master
         ReqOut:
           Or:
           - Dashes: two
-            Diffculty: expert
+            Difficulty: expert
           - Dashes: one
-            Difficulty: perfect
+            Difficulty: perfect  
   - Room: "b-05"
     Holes:
     - Side: Left
@@ -2369,7 +2369,7 @@ BSide:
       Kind: in
     - Side: Down
       Idx: 1
-      kind: unknown
+      Kind: unknown
       LowBound: 13
       HighBound: 15
   - Room: "d-04"
@@ -2394,7 +2394,7 @@ BSide:
       ReqIn:
         Or:
           - Dashes: one
-            Diffculty: hard
+            Difficulty: hard
           - Dashes: two
   - Room: "d-05"
     ReqEnd:

--- a/Randomizer/Config/Celeste/7-Summit.rando.yaml
+++ b/Randomizer/Config/Celeste/7-Summit.rando.yaml
@@ -2306,7 +2306,7 @@ ASide:
         Or:
         - Dashes: one
         - Dashes: zero
-          Dificulty: hard
+          Difficulty: hard
       ReqIn:
         Dashes: zero
     - To: "left"
@@ -2909,7 +2909,10 @@ ASide:
     InternalEdges:
     - Split: LeftToRight
       ReqOut:
-        Dashes: two
+        Or:
+        - Dashes: two
+        - Dashes: one
+          Difficulty: perfect
       ReqIn:
         Dashes: two
         Difficulty: hard

--- a/Randomizer/Config/Celeste/7-Summit.rando.yaml
+++ b/Randomizer/Config/Celeste/7-Summit.rando.yaml
@@ -3777,7 +3777,7 @@ BSide:
     Holes:
     - Side: Up
       Idx: 0
-      Kind: inout
+      Kind: out
       Launch: 19
       ReqOut:
         Or:

--- a/Randomizer/Config/Celeste/9-Core.rando.yaml
+++ b/Randomizer/Config/Celeste/9-Core.rando.yaml
@@ -214,7 +214,7 @@ ASide:
       ReqOut:
         Or:
         - Dashes: two
-          Diffuclty: hard
+          Difficulty: hard
         - Dashes: one
           Difficulty: Perfect
     - Side: Right

--- a/Randomizer/Config/Celeste/LostLevels.rando.yaml
+++ b/Randomizer/Config/Celeste/LostLevels.rando.yaml
@@ -1512,17 +1512,44 @@ ASide:
             Difficulty: master
   - Room: "h-01"
     Holes:
-    - Side: Up
+    - Side: Left
       Idx: 0
-      Kind: out
+      Kind: inout
+    InternalEdges:
+    - To: "top"
       ReqOut:
         Or:
         - Dashes: two
         - Dashes: one
           Difficulty: hard
-    - Side: Left
-      Idx: 0
-      Kind: in
+      ReqIn: 
+        Or:
+        - Dashes: two
+          Difficulty: hard
+        - Dashes: one
+          Difficulty: hard
+    Subrooms:
+    - Room: "top"
+      Holes:
+      - Side: Up
+        Idx: 0
+        Kind: inout
+    Tweaks:
+    - Name: "cameraOffsetTrigger"
+      Update:
+        Add: true
+        X: 256
+        Y: 24
+        Width: 24
+        Height: 8
+        Values:  
+          cameraX: 0
+          cameraY: 1.5
+    - Name: spawn
+      Update:
+        Add: true
+        X: 272
+        Y: 24        
   - Room: "h-02"
     Holes:
     - Side: Right

--- a/Randomizer/Config/Celeste/LostLevels.rando.yaml
+++ b/Randomizer/Config/Celeste/LostLevels.rando.yaml
@@ -237,7 +237,10 @@ ASide:
       ReqOut:
         Dashes: one
       ReqIn:
-        Dashes: two
+        Or:
+        - Dashes: two
+        - Dashes: one
+          Difficulty: perfect
   - Room: "b-02"
     Holes:
     - Side: Right
@@ -860,10 +863,10 @@ ASide:
         Dashes: one
       ReqIn: 
         Or:
-        Dashes: two
-        Difficulty: perfect
-        Dashes: one
-        Difficulty: perfect
+        - Dashes: two
+          Difficulty: perfect
+        - Dashes: one
+          Difficulty: perfect
     Tweaks:
     - Name: spawn
       Update: 
@@ -1241,7 +1244,7 @@ ASide:
         Or:
         - Dashes: two
         - Dashes: one
-          Diffiulty: hard
+          Difficulty: hard
       ReqIn:
         Dashes: one
     Tweaks:

--- a/Randomizer/Config/Celeste/LostLevels.rando.yaml
+++ b/Randomizer/Config/Celeste/LostLevels.rando.yaml
@@ -951,14 +951,9 @@ ASide:
       Kind: none
   - Room: "e-04"
     Holes:
-    - Side: Right
-      Idx: 0
-      Kind: out
-      ReqOut:
-        Dashes: one
     - Side: Left
       Idx: 0
-      Kind: in
+      Kind: inout
     - Side: down
       Idx: 0
       Kind: None
@@ -968,6 +963,19 @@ ASide:
     - Side: down
       Idx: 2
       Kind: None
+    InternalEdges:
+    - To: "right"
+      ReqOut:
+        Dashes: one
+      ReqIn: 
+        Dashes: two
+        Difficulty: perfect
+    Subrooms:
+    - Room: "right"
+      Holes:
+      - Side: Right
+        Idx: 0
+        Kind: inout
     ExtraSpace:
     - X: 472
       Y: 176


### PR DESCRIPTION
alot of fixes came from [androix](https://discord.com/channels/403698615446536203/738558439227392082/1168631697676439652): syntax problems and spelling errors ect (in 3a, 4a, 5a, 5b, 7a, 8a and fw)

also fixed: 
- 5b a-02 ltr and rtl issues by removing right hole from default subroom 
- 7b b-03 issues related to the orb (i changed it to inout for some reason while changing b-02)

changed:
- 3a s2 collectible 1 dash to hard
- 5a b-11 top left exit to hard

added:
- 4b d-03 left exit 2x perfect
- 7a f-09 right exit 1x perfect
- fw b-01 left exit 1x perfect
- fw e-04 rtl 2x perfect