### PR TITLE
Refactor map generation to enable ModInterop-based generation initiated by other mods

### DIFF
--- a/Randomizer/Builder.cs
+++ b/Randomizer/Builder.cs
@@ -1,0 +1,162 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Celeste.Mod.Randomizer {
+	public class Builder : IDisposable {
+
+		/// <summary>
+		/// Possible Builder statuses. Values are ardered by priority so status may only increase in value, so numeric comparisons may be used.
+		/// </summary>
+		public enum BuilderStatus {
+			NotStarted = 0,
+			WaitingForThread = 10,
+			Running = 20,
+			Success = 30,
+			Error = 40,
+			Abort = 50,
+			Disposed = 99999,
+		}
+
+		/// <summary>
+		/// Callback to execute on success
+		/// </summary>
+		public Action<AreaKey> OnSuccess { get; set; }
+
+		/// <summary>
+		/// Callback to execute on error
+		/// </summary>
+		public Action<Exception> OnError { get; set; }
+
+		/// <summary>
+		/// Callback to execute on abort
+		/// </summary>
+		public Action OnAbort { get; set; }
+
+		/// <summary>
+		/// The status of the worker. For thread safety, threadLock is required when setting.
+		/// </summary>
+		public BuilderStatus Status {
+			get {
+				lock (threadLock) {
+					return _status;
+				}
+			}
+			private set {
+				if (value > _status) _status = value;
+			}
+		}
+
+		/// <summary>
+		/// Generic object used as the lock target for thread-safe operation
+		/// </summary>
+		private object threadLock = new object();
+
+		private Thread worker = null;
+		private RandoSettings settings;
+		private volatile BuilderStatus _status = BuilderStatus.NotStarted;
+		private volatile Exception exception = null;
+		private AreaKey? generatedArea = null;
+
+		public Builder() { }
+
+		/// <summary>
+		/// Begin building
+		/// </summary>
+		public void Go(RandoSettings settings) {
+			lock(threadLock) {
+				if (Status > BuilderStatus.WaitingForThread) return;
+				Status = BuilderStatus.WaitingForThread;
+			}
+			this.settings = settings.Copy();
+			worker = new Thread(BackgroundThreadMain) { IsBackground = true };
+			worker.Start();
+		}
+
+		/// <summary>
+		/// Abort the build if it has been started and dispose of resources
+		/// </summary>
+		public void Abort() {
+			lock (threadLock) {
+				if (Status == BuilderStatus.Disposed) return;
+				worker?.Abort();
+				Status = BuilderStatus.Disposed;
+			}
+		}
+
+		/// <summary>
+		/// Call this on the main thread to check its status and trigger OnSuccess/OnError/OnAbort events if necessary.
+		/// </summary>
+		/// <returns>True if the builder is finished and can be disposed.</returns>
+		public bool Check() {
+			lock(threadLock) {
+				BuilderStatus status = Status;
+				if (status < BuilderStatus.Success || status == BuilderStatus.Disposed) return false;
+				RandoModule.Instance.SavedData.SavedSettings = settings;
+				RandoModule.Instance.SaveSettings();
+				switch (status) {
+					case BuilderStatus.Success:
+						OnSuccess?.Invoke(generatedArea.Value);
+						break;
+					case BuilderStatus.Error:
+						OnError?.Invoke(exception);
+						break;
+					case BuilderStatus.Abort:
+						OnAbort?.Invoke();
+						break;
+					default:
+						Logger.Log(LogLevel.Error, "Randomizer", $"Randomizer builder encountered a mysetry status: '{status}'");
+						break;
+				}
+				Dispose();
+				return true;
+			}
+		}
+
+		/// <summary>
+		/// Dispose of resources
+		/// </summary>
+		public void Dispose() {
+			lock (threadLock) {
+				if (Status == BuilderStatus.Disposed) return;
+				worker?.Abort();
+				Status = BuilderStatus.Disposed;
+			}
+		}
+
+		/// <summary>
+		/// Main function for the worker thread. Performs the map build.
+		/// </summary>
+		private void BackgroundThreadMain() {
+			Status = BuilderStatus.Running;
+			settings.Enforce();
+			AreaKey newArea;
+			try {
+				newArea = RandoLogic.GenerateMap(settings);
+			}
+			catch (ThreadAbortException) {
+				lock (threadLock) {
+					Status = BuilderStatus.Abort;
+					worker = null;
+				}
+				return;
+			}
+			catch (Exception e) {
+				lock (threadLock) {
+					exception = e;
+					Status = BuilderStatus.Error;
+					worker = null;
+				}
+				return;
+			}
+			lock(threadLock) {
+				generatedArea = newArea;
+				Status = BuilderStatus.Success;
+				worker = null;
+			}
+		}
+	}
+}

--- a/Randomizer/Interoperability/GenerationInterop.cs
+++ b/Randomizer/Interoperability/GenerationInterop.cs
@@ -6,12 +6,76 @@ using System.Text;
 using System.Threading.Tasks;
 
 namespace Celeste.Mod.Randomizer.Interoperability {
+
+	/// <summary>
+	/// Interop class to allow other mods to trigger randomizer generation
+	/// </summary>
 	[ModExportName("Randomizer.GenerationInterop")]
 	public static class GenerationInterop {
-		public static object Generate(object settings) {
+		private static Builder.BuilderStatus status = Builder.BuilderStatus.NotStarted;
+		private static AreaKey? generatedArea = null;
+
+		/// <summary>
+		/// Starts randomizer map generation
+		/// </summary>
+		/// <param name="settings">the settings object to use for generation</param>
+		/// <returns>True if generation was successfully started, false if it could not be started</returns>
+		/// <exception cref="ArgumentException">thrown when the settings parameter is not an instance of RandoSettings</exception>
+		public static bool Generate(object settings) {
 			RandoSettings s = settings as RandoSettings ?? InteropHelper.TypeError<RandoSettings>(settings);
-			// TODO (corkr900)
-			return null;
+			if (RandoModule.MapBuilder != null) {
+				Logger.Log(LogLevel.Warn, "Randomizer.GenerationInterop", "Cannot start generation; another is already in progress");
+				return false;
+			}
+			Builder b = new Builder();
+			b.OnAbort = () => {
+				status = Builder.BuilderStatus.Abort;
+			};
+			b.OnError = (Exception e) => {
+				status = Builder.BuilderStatus.Error;
+			};
+			b.OnSuccess = (AreaKey newArea) => {
+				generatedArea = newArea;
+				status = Builder.BuilderStatus.Success;
+			};
+			RandoModule.MapBuilder = b;
+			b.Go(s);
+			status = Builder.BuilderStatus.Running;
+			generatedArea = null;
+			return true;
 		}
+
+		/// <summary>
+		/// Gets whether rando map generation via interop is currently running
+		/// </summary>
+		/// <returns>true if an interop-initiated map generation is in progress, otherwise false</returns>
+		public static bool GenerationInProgress() {
+			return status == Builder.BuilderStatus.Running;
+		}
+
+		/// <summary>
+		/// Gets whether rando map generation via interop is finished and the map ready to enter
+		/// </summary>
+		/// <returns>true if an interop-initiated map generation is finished and the area ready, otherwise false</returns>
+		public static bool ReadyToLaunch() {
+			return status == Builder.BuilderStatus.Success && generatedArea != null;
+		}
+
+		public static AreaKey? GetGeneratedArea() {
+			return generatedArea;
+		}
+
+		/// <summary>
+		/// Enter the rando level generated via interop
+		/// </summary>
+		/// <returns>true if the launch provccess was started successfully, otherwise false</returns>
+		public static bool EnterGeneratedArea() {
+			if (!ReadyToLaunch()) return false;
+			RandoModule.LaunchIntoRandoArea(generatedArea.Value);
+			status = Builder.BuilderStatus.NotStarted;
+			generatedArea = null;
+			return true;
+		}
+
 	}
 }

--- a/Randomizer/Interoperability/GenerationInterop.cs
+++ b/Randomizer/Interoperability/GenerationInterop.cs
@@ -1,0 +1,17 @@
+﻿using MonoMod.ModInterop;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Celeste.Mod.Randomizer.Interoperability {
+	[ModExportName("Randomizer.GenerationInterop")]
+	public static class GenerationInterop {
+		public static object Generate(object settings) {
+			RandoSettings s = settings as RandoSettings ?? InteropHelper.TypeError<RandoSettings>(settings);
+			// TODO (corkr900)
+			return null;
+		}
+	}
+}

--- a/Randomizer/Interoperability/InteropHelper.cs
+++ b/Randomizer/Interoperability/InteropHelper.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Celeste.Mod.Randomizer.Interoperability {
+	internal static class InteropHelper {
+
+		/// <summary>
+		/// Throws an error describing a misuse of the ModInterop API
+		/// </summary>
+		/// <param name="arg">the object that was passed in place of the settings</param>
+		/// <returns>never</returns>
+		/// <exception cref="ArgumentException">Thrown always with a formatted error message</exception>
+		internal static T TypeError<T>(object arg) {
+			throw new ArgumentException($"Randomizer.Interop: received an object of type '{arg?.GetType()?.Name ?? "null"}', expected {typeof(T).Name}");
+		}
+
+	}
+}

--- a/Randomizer/Interoperability/SettingsInterop.cs
+++ b/Randomizer/Interoperability/SettingsInterop.cs
@@ -1,0 +1,224 @@
+﻿using MonoMod.ModInterop;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Celeste.Mod.Randomizer.Interoperability {
+	[ModExportName("Randomizer.SettingsInterop")]
+	public static class SettingsInterop {
+
+		/// <summary>
+		/// Creates an instance of RandoSettings
+		/// </summary>
+		/// <returns></returns>
+		public static object GetSettingsObject() {
+			return new RandoSettings();
+		}
+
+		/// <summary>
+		/// Enables the given map in the given settings object
+		/// </summary>
+		/// <param name="settings">The settings object</param>
+		/// <param name="area">The map to enable</param>
+		/// <exception cref="ArgumentException">Thrown when the parameter is not an instance of RandoSettings</exception>
+		public static void EnableMap(object settings, AreaKey area) {
+			RandoSettings s = settings as RandoSettings ?? TypeError(settings);
+			s.EnableMap(area);
+		}
+
+		/// <summary>
+		/// Enables all given maps in the given settings object
+		/// </summary>
+		/// <param name="settings">The settings object</param>
+		/// <param name="areas">An enumerable set of maps to enable</param>
+		/// <exception cref="ArgumentException">Thrown when the parameter is not an instance of RandoSettings</exception>
+		public static void EnableMaps(object settings, IEnumerable<AreaKey> areas) {
+			RandoSettings s = settings as RandoSettings ?? TypeError(settings);
+			if (areas == null) throw new ArgumentNullException(nameof(areas));
+            foreach (var area in areas)
+            {
+				s.EnableMap(area);
+            }
+		}
+
+		/// <summary>
+		/// Enables all vanilla maps in the given settings object
+		/// </summary>
+		/// <param name="settings">The settings object</param>
+		/// <exception cref="ArgumentException">Thrown when the parameter is not an instance of RandoSettings</exception>
+		public static void EnableVanillaMaps(object settings) {
+			RandoSettings s = settings as RandoSettings ?? TypeError(settings);
+
+			s.EnableMap(new AreaKey(0, AreaMode.Normal));
+			s.EnableMap(new AreaKey(1, AreaMode.Normal));
+			s.EnableMap(new AreaKey(2, AreaMode.Normal));
+			s.EnableMap(new AreaKey(3, AreaMode.Normal));
+			s.EnableMap(new AreaKey(4, AreaMode.Normal));
+			s.EnableMap(new AreaKey(5, AreaMode.Normal));
+			s.EnableMap(new AreaKey(6, AreaMode.Normal));
+			s.EnableMap(new AreaKey(7, AreaMode.Normal));
+			s.EnableMap(new AreaKey(9, AreaMode.Normal));
+			s.EnableMap(new AreaKey(10, AreaMode.Normal));
+
+			s.EnableMap(new AreaKey(1, AreaMode.BSide));
+			s.EnableMap(new AreaKey(2, AreaMode.BSide));
+			s.EnableMap(new AreaKey(3, AreaMode.BSide));
+			s.EnableMap(new AreaKey(4, AreaMode.BSide));
+			s.EnableMap(new AreaKey(5, AreaMode.BSide));
+			s.EnableMap(new AreaKey(6, AreaMode.BSide));
+			s.EnableMap(new AreaKey(7, AreaMode.BSide));
+			s.EnableMap(new AreaKey(9, AreaMode.BSide));
+
+			s.EnableMap(new AreaKey(1, AreaMode.CSide));
+			s.EnableMap(new AreaKey(2, AreaMode.CSide));
+			s.EnableMap(new AreaKey(3, AreaMode.CSide));
+			s.EnableMap(new AreaKey(4, AreaMode.CSide));
+			s.EnableMap(new AreaKey(5, AreaMode.CSide));
+			s.EnableMap(new AreaKey(6, AreaMode.CSide));
+			s.EnableMap(new AreaKey(7, AreaMode.CSide));
+			s.EnableMap(new AreaKey(9, AreaMode.CSide));
+		}
+
+		/// <summary>
+		/// Sets the Rules value on the given RandoSettings object
+		/// </summary>
+		/// <param name="settings">The settings object</param>
+		/// <param name="strawberriesStr">The value to set</param>
+		/// <exception cref="ArgumentException">Thrown when the first parameter is not an instance of RandoSettings</exception>
+		public static void SetSeed(object settings, string seed) {
+			RandoSettings s = settings as RandoSettings ?? TypeError(settings);
+			s.Seed = seed;
+		}
+
+		/// <summary>
+		/// Sets the Rules value on the given RandoSettings object
+		/// </summary>
+		/// <param name="settings">The settings object</param>
+		/// <param name="strawberriesStr">The value to set</param>
+		/// <exception cref="ArgumentException">Thrown when the first parameter is not an instance of RandoSettings</exception>
+		public static void SetRules(object settings, string rules) {
+			RandoSettings s = settings as RandoSettings ?? TypeError(settings);
+			s.Rules = rules;
+		}
+
+		/// <summary>
+		/// Sets the SeedType value on the given RandoSettings object
+		/// </summary>
+		/// <param name="settings">The settings object</param>
+		/// <param name="strawberriesStr">The value to set. Will be parsed to the appropriate enum.</param>
+		/// <returns>True if the arguments were valid and the value was set, false if the value is not a valid enum value</returns>
+		/// <exception cref="ArgumentException">Thrown when the first parameter is not an instance of RandoSettings</exception>
+		public static bool SetSeedType(object settings, string seedTypeStr) {
+			RandoSettings s = settings as RandoSettings ?? TypeError(settings);
+			return Enum.TryParse(seedTypeStr, out s.SeedType);
+		}
+
+		/// <summary>
+		/// Sets the Algorithm value on the given RandoSettings object
+		/// </summary>
+		/// <param name="settings">The settings object</param>
+		/// <param name="strawberriesStr">The value to set. Will be parsed to the appropriate enum.</param>
+		/// <returns>True if the arguments were valid and the value was set, false if the value is not a valid enum value</returns>
+		/// <exception cref="ArgumentException">Thrown when the first parameter is not an instance of RandoSettings</exception>
+		public static bool SetAlgorithm(object settings, string algorithmStr) {
+			RandoSettings s = settings as RandoSettings ?? TypeError(settings);
+			return Enum.TryParse(algorithmStr, out s.Algorithm);
+		}
+
+		/// <summary>
+		/// Sets the Dashes value on the given RandoSettings object
+		/// </summary>
+		/// <param name="settings">The settings object</param>
+		/// <param name="strawberriesStr">The value to set. Will be parsed to the appropriate enum.</param>
+		/// <returns>True if the arguments were valid and the value was set, false if the value is not a valid enum value</returns>
+		/// <exception cref="ArgumentException">Thrown when the first parameter is not an instance of RandoSettings</exception>
+		public static bool SetDashes(object settings, string dashesStr) {
+			RandoSettings s = settings as RandoSettings ?? TypeError(settings);
+			return Enum.TryParse(dashesStr, out s.Dashes);
+		}
+
+		/// <summary>
+		/// Sets the Difficulty value on the given RandoSettings object
+		/// </summary>
+		/// <param name="settings">The settings object</param>
+		/// <param name="strawberriesStr">The value to set. Will be parsed to the appropriate enum.</param>
+		/// <returns>True if the arguments were valid and the value was set, false if the value is not a valid enum value</returns>
+		/// <exception cref="ArgumentException">Thrown when the first parameter is not an instance of RandoSettings</exception>
+		public static bool SetDifficulty(object settings, string difficultyStr) {
+			RandoSettings s = settings as RandoSettings ?? TypeError(settings);
+			return Enum.TryParse(difficultyStr, out s.Difficulty);
+		}
+
+		/// <summary>
+		/// Sets the Difficulty Eagerness value on the given RandoSettings object
+		/// </summary>
+		/// <param name="settings">The settings object</param>
+		/// <param name="strawberriesStr">The value to set. Will be parsed to the appropriate enum.</param>
+		/// <returns>True if the arguments were valid and the value was set, false if the value is not a valid enum value</returns>
+		/// <exception cref="ArgumentException">Thrown when the first parameter is not an instance of RandoSettings</exception>
+		public static bool SetDifficultyEagerness(object settings, string difficultyEagernessStr) {
+			RandoSettings s = settings as RandoSettings ?? TypeError(settings);
+			return Enum.TryParse(difficultyEagernessStr, out s.DifficultyEagerness);
+		}
+
+		/// <summary>
+		/// Sets the Length value on the given RandoSettings object
+		/// </summary>
+		/// <param name="settings">The settings object</param>
+		/// <param name="strawberriesStr">The value to set. Will be parsed to the appropriate enum.</param>
+		/// <returns>True if the arguments were valid and the value was set, false if the value is not a valid enum value</returns>
+		/// <exception cref="ArgumentException">Thrown when the first parameter is not an instance of RandoSettings</exception>
+		public static bool SetLength(object settings, string lengthStr) {
+			RandoSettings s = settings as RandoSettings ?? TypeError(settings);
+			return Enum.TryParse(lengthStr, out s.Length);
+		}
+
+		/// <summary>
+		/// Sets the Lights value on the given RandoSettings object
+		/// </summary>
+		/// <param name="settings">The settings object</param>
+		/// <param name="strawberriesStr">The value to set. Will be parsed to the appropriate enum.</param>
+		/// <returns>True if the arguments were valid and the value was set, false if the value is not a valid enum value</returns>
+		/// <exception cref="ArgumentException">Thrown when the first parameter is not an instance of RandoSettings</exception>
+		public static bool SetLights(object settings, string lightsStr) {
+			RandoSettings s = settings as RandoSettings ?? TypeError(settings);
+			return Enum.TryParse(lightsStr, out s.Lights);
+		}
+
+		/// <summary>
+		/// Sets the Darkness value on the given RandoSettings object
+		/// </summary>
+		/// <param name="settings">The settings object</param>
+		/// <param name="strawberriesStr">The value to set. Will be parsed to the appropriate enum.</param>
+		/// <returns>True if the arguments were valid and the value was set, false if the value is not a valid enum value</returns>
+		/// <exception cref="ArgumentException">Thrown when the first parameter is not an instance of RandoSettings</exception>
+		public static bool SetDarkness(object settings, string darknessStr) {
+			RandoSettings s = settings as RandoSettings ?? TypeError(settings);
+			return Enum.TryParse(darknessStr, out s.Darkness);
+		}
+
+		/// <summary>
+		/// Sets the Strawberries value on the given RandoSettings object
+		/// </summary>
+		/// <param name="settings">The settings object</param>
+		/// <param name="strawberriesStr">The value to set. Will be parsed to the appropriate enum.</param>
+		/// <returns>True if the arguments were valid and the value was set, false if the value is not a valid enum value</returns>
+		/// <exception cref="ArgumentException">Thrown when the first parameter is not an instance of RandoSettings</exception>
+		public static bool SetStrawberries(object settings, string strawberriesStr) {
+			RandoSettings s = settings as RandoSettings ?? TypeError(settings);
+			return Enum.TryParse(strawberriesStr, out s.Strawberries);
+		}
+
+		/// <summary>
+		/// Throws an error describing a misuse of the ModInterop API
+		/// </summary>
+		/// <param name="settings">the object that was passed in place of the settings</param>
+		/// <returns>never</returns>
+		/// <exception cref="ArgumentException">Thrown always with a formatted error message</exception>
+		private static RandoSettings TypeError(object settings) {
+			throw new ArgumentException($"Randomizer.SettingsInterop: received an object of type '{settings?.GetType()?.Name ?? "null"}', expected RandoSettings");
+		}
+	}
+}

--- a/Randomizer/Interoperability/SettingsInterop.cs
+++ b/Randomizer/Interoperability/SettingsInterop.cs
@@ -24,7 +24,7 @@ namespace Celeste.Mod.Randomizer.Interoperability {
 		/// <param name="area">The map to enable</param>
 		/// <exception cref="ArgumentException">Thrown when the parameter is not an instance of RandoSettings</exception>
 		public static void EnableMap(object settings, AreaKey area) {
-			RandoSettings s = settings as RandoSettings ?? TypeError(settings);
+			RandoSettings s = settings as RandoSettings ?? InteropHelper.TypeError<RandoSettings>(settings);
 			s.EnableMap(area);
 		}
 
@@ -35,7 +35,7 @@ namespace Celeste.Mod.Randomizer.Interoperability {
 		/// <param name="areas">An enumerable set of maps to enable</param>
 		/// <exception cref="ArgumentException">Thrown when the parameter is not an instance of RandoSettings</exception>
 		public static void EnableMaps(object settings, IEnumerable<AreaKey> areas) {
-			RandoSettings s = settings as RandoSettings ?? TypeError(settings);
+			RandoSettings s = settings as RandoSettings ?? InteropHelper.TypeError<RandoSettings>(settings);
 			if (areas == null) throw new ArgumentNullException(nameof(areas));
             foreach (var area in areas)
             {
@@ -49,7 +49,7 @@ namespace Celeste.Mod.Randomizer.Interoperability {
 		/// <param name="settings">The settings object</param>
 		/// <exception cref="ArgumentException">Thrown when the parameter is not an instance of RandoSettings</exception>
 		public static void EnableVanillaMaps(object settings) {
-			RandoSettings s = settings as RandoSettings ?? TypeError(settings);
+			RandoSettings s = settings as RandoSettings ?? InteropHelper.TypeError<RandoSettings>(settings);
 
 			s.EnableMap(new AreaKey(0, AreaMode.Normal));
 			s.EnableMap(new AreaKey(1, AreaMode.Normal));
@@ -88,7 +88,7 @@ namespace Celeste.Mod.Randomizer.Interoperability {
 		/// <param name="strawberriesStr">The value to set</param>
 		/// <exception cref="ArgumentException">Thrown when the first parameter is not an instance of RandoSettings</exception>
 		public static void SetSeed(object settings, string seed) {
-			RandoSettings s = settings as RandoSettings ?? TypeError(settings);
+			RandoSettings s = settings as RandoSettings ?? InteropHelper.TypeError<RandoSettings>(settings);
 			s.Seed = seed;
 		}
 
@@ -99,7 +99,7 @@ namespace Celeste.Mod.Randomizer.Interoperability {
 		/// <param name="strawberriesStr">The value to set</param>
 		/// <exception cref="ArgumentException">Thrown when the first parameter is not an instance of RandoSettings</exception>
 		public static void SetRules(object settings, string rules) {
-			RandoSettings s = settings as RandoSettings ?? TypeError(settings);
+			RandoSettings s = settings as RandoSettings ?? InteropHelper.TypeError<RandoSettings>(settings);
 			s.Rules = rules;
 		}
 
@@ -111,7 +111,7 @@ namespace Celeste.Mod.Randomizer.Interoperability {
 		/// <returns>True if the arguments were valid and the value was set, false if the value is not a valid enum value</returns>
 		/// <exception cref="ArgumentException">Thrown when the first parameter is not an instance of RandoSettings</exception>
 		public static bool SetSeedType(object settings, string seedTypeStr) {
-			RandoSettings s = settings as RandoSettings ?? TypeError(settings);
+			RandoSettings s = settings as RandoSettings ?? InteropHelper.TypeError<RandoSettings>(settings);
 			return Enum.TryParse(seedTypeStr, out s.SeedType);
 		}
 
@@ -123,7 +123,7 @@ namespace Celeste.Mod.Randomizer.Interoperability {
 		/// <returns>True if the arguments were valid and the value was set, false if the value is not a valid enum value</returns>
 		/// <exception cref="ArgumentException">Thrown when the first parameter is not an instance of RandoSettings</exception>
 		public static bool SetAlgorithm(object settings, string algorithmStr) {
-			RandoSettings s = settings as RandoSettings ?? TypeError(settings);
+			RandoSettings s = settings as RandoSettings ?? InteropHelper.TypeError<RandoSettings>(settings);
 			return Enum.TryParse(algorithmStr, out s.Algorithm);
 		}
 
@@ -135,7 +135,7 @@ namespace Celeste.Mod.Randomizer.Interoperability {
 		/// <returns>True if the arguments were valid and the value was set, false if the value is not a valid enum value</returns>
 		/// <exception cref="ArgumentException">Thrown when the first parameter is not an instance of RandoSettings</exception>
 		public static bool SetDashes(object settings, string dashesStr) {
-			RandoSettings s = settings as RandoSettings ?? TypeError(settings);
+			RandoSettings s = settings as RandoSettings ?? InteropHelper.TypeError<RandoSettings>(settings);
 			return Enum.TryParse(dashesStr, out s.Dashes);
 		}
 
@@ -147,7 +147,7 @@ namespace Celeste.Mod.Randomizer.Interoperability {
 		/// <returns>True if the arguments were valid and the value was set, false if the value is not a valid enum value</returns>
 		/// <exception cref="ArgumentException">Thrown when the first parameter is not an instance of RandoSettings</exception>
 		public static bool SetDifficulty(object settings, string difficultyStr) {
-			RandoSettings s = settings as RandoSettings ?? TypeError(settings);
+			RandoSettings s = settings as RandoSettings ?? InteropHelper.TypeError<RandoSettings>(settings);
 			return Enum.TryParse(difficultyStr, out s.Difficulty);
 		}
 
@@ -159,7 +159,7 @@ namespace Celeste.Mod.Randomizer.Interoperability {
 		/// <returns>True if the arguments were valid and the value was set, false if the value is not a valid enum value</returns>
 		/// <exception cref="ArgumentException">Thrown when the first parameter is not an instance of RandoSettings</exception>
 		public static bool SetDifficultyEagerness(object settings, string difficultyEagernessStr) {
-			RandoSettings s = settings as RandoSettings ?? TypeError(settings);
+			RandoSettings s = settings as RandoSettings ?? InteropHelper.TypeError<RandoSettings>(settings);
 			return Enum.TryParse(difficultyEagernessStr, out s.DifficultyEagerness);
 		}
 
@@ -171,7 +171,7 @@ namespace Celeste.Mod.Randomizer.Interoperability {
 		/// <returns>True if the arguments were valid and the value was set, false if the value is not a valid enum value</returns>
 		/// <exception cref="ArgumentException">Thrown when the first parameter is not an instance of RandoSettings</exception>
 		public static bool SetLength(object settings, string lengthStr) {
-			RandoSettings s = settings as RandoSettings ?? TypeError(settings);
+			RandoSettings s = settings as RandoSettings ?? InteropHelper.TypeError<RandoSettings>(settings);
 			return Enum.TryParse(lengthStr, out s.Length);
 		}
 
@@ -183,7 +183,7 @@ namespace Celeste.Mod.Randomizer.Interoperability {
 		/// <returns>True if the arguments were valid and the value was set, false if the value is not a valid enum value</returns>
 		/// <exception cref="ArgumentException">Thrown when the first parameter is not an instance of RandoSettings</exception>
 		public static bool SetLights(object settings, string lightsStr) {
-			RandoSettings s = settings as RandoSettings ?? TypeError(settings);
+			RandoSettings s = settings as RandoSettings ?? InteropHelper.TypeError<RandoSettings>(settings);
 			return Enum.TryParse(lightsStr, out s.Lights);
 		}
 
@@ -195,7 +195,7 @@ namespace Celeste.Mod.Randomizer.Interoperability {
 		/// <returns>True if the arguments were valid and the value was set, false if the value is not a valid enum value</returns>
 		/// <exception cref="ArgumentException">Thrown when the first parameter is not an instance of RandoSettings</exception>
 		public static bool SetDarkness(object settings, string darknessStr) {
-			RandoSettings s = settings as RandoSettings ?? TypeError(settings);
+			RandoSettings s = settings as RandoSettings ?? InteropHelper.TypeError<RandoSettings>(settings);
 			return Enum.TryParse(darknessStr, out s.Darkness);
 		}
 
@@ -207,18 +207,9 @@ namespace Celeste.Mod.Randomizer.Interoperability {
 		/// <returns>True if the arguments were valid and the value was set, false if the value is not a valid enum value</returns>
 		/// <exception cref="ArgumentException">Thrown when the first parameter is not an instance of RandoSettings</exception>
 		public static bool SetStrawberries(object settings, string strawberriesStr) {
-			RandoSettings s = settings as RandoSettings ?? TypeError(settings);
+			RandoSettings s = settings as RandoSettings ?? InteropHelper.TypeError<RandoSettings>(settings);
 			return Enum.TryParse(strawberriesStr, out s.Strawberries);
 		}
 
-		/// <summary>
-		/// Throws an error describing a misuse of the ModInterop API
-		/// </summary>
-		/// <param name="settings">the object that was passed in place of the settings</param>
-		/// <returns>never</returns>
-		/// <exception cref="ArgumentException">Thrown always with a formatted error message</exception>
-		private static RandoSettings TypeError(object settings) {
-			throw new ArgumentException($"Randomizer.SettingsInterop: received an object of type '{settings?.GetType()?.Name ?? "null"}', expected RandoSettings");
-		}
 	}
 }

--- a/Randomizer/Interoperability/SettingsInterop.cs
+++ b/Randomizer/Interoperability/SettingsInterop.cs
@@ -6,6 +6,10 @@ using System.Text;
 using System.Threading.Tasks;
 
 namespace Celeste.Mod.Randomizer.Interoperability {
+
+	/// <summary>
+	/// Interop class that allows other mods to build a RandoSettings object
+	/// </summary>
 	[ModExportName("Randomizer.SettingsInterop")]
 	public static class SettingsInterop {
 

--- a/Randomizer/RandoModule.cs
+++ b/Randomizer/RandoModule.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using System.Reflection;
 using System.Collections.Generic;
 using MonoMod.Utils;
+using Celeste.Mod.Randomizer.Interoperability;
+using MonoMod.ModInterop;
 
 namespace Celeste.Mod.Randomizer {
     public partial class RandoModule : EverestModule {
@@ -57,6 +59,7 @@ namespace Celeste.Mod.Randomizer {
             LoadSessionLifecycle();
             LoadMenuLifecycle();
             Entities.LifeBerry.Load();
+            typeof(SettingsInterop).ModInterop();
         }
 
         public Action ResetExtendedVariants;

--- a/Randomizer/RandoModule.cs
+++ b/Randomizer/RandoModule.cs
@@ -59,8 +59,9 @@ namespace Celeste.Mod.Randomizer {
             LoadSessionLifecycle();
             LoadMenuLifecycle();
             Entities.LifeBerry.Load();
-            typeof(SettingsInterop).ModInterop();
-        }
+			typeof(GenerationInterop).ModInterop();
+			typeof(SettingsInterop).ModInterop();
+		}
 
         public Action ResetExtendedVariants;
         public Action ResetIsaVariants;

--- a/Randomizer/Randomizer.csproj
+++ b/Randomizer/Randomizer.csproj
@@ -82,8 +82,10 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Builder.cs" />
     <Compile Include="Entities\FindTheoPhone.cs" />
     <Compile Include="Entities\LifeBerry.cs" />
+    <Compile Include="Interoperability\SettingsInterop.cs" />
     <Compile Include="Oui\GenericOui.cs" />
     <Compile Include="Oui\OuiRandoDifficulty.cs" />
     <Compile Include="Oui\OuiRandoMode.cs" />
@@ -400,12 +402,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Config\" />
-    <Folder Include="Dialog\" />
-    <Folder Include="Graphics\" />
-    <Folder Include="RandoLogic\" />
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>
     <MonoDevelop>

--- a/Randomizer/Randomizer.csproj
+++ b/Randomizer/Randomizer.csproj
@@ -415,4 +415,11 @@
       </Properties>
     </MonoDevelop>
   </ProjectExtensions>
+  <PropertyGroup Condition="'$(COPY_OUTPUT_TO_DIR)' != ''">
+    <PostBuildEvent>
+      echo POST-BUILD: Copying Randomizer.dll and Randomizer.pdb from "$(TargetDir)" to "$(COPY_OUTPUT_TO_DIR)"...
+      copy "$(TargetDir)\Randomizer.dll" "$(COPY_OUTPUT_TO_DIR)\Randomizer.dll"
+      copy "$(TargetDir)\Randomizer.pdb" "$(COPY_OUTPUT_TO_DIR)\Randomizer.pdb"
+    </PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/Randomizer/Randomizer.csproj
+++ b/Randomizer/Randomizer.csproj
@@ -85,6 +85,8 @@
     <Compile Include="Builder.cs" />
     <Compile Include="Entities\FindTheoPhone.cs" />
     <Compile Include="Entities\LifeBerry.cs" />
+    <Compile Include="Interoperability\GenerationInterop.cs" />
+    <Compile Include="Interoperability\InteropHelper.cs" />
     <Compile Include="Interoperability\SettingsInterop.cs" />
     <Compile Include="Oui\GenericOui.cs" />
     <Compile Include="Oui\OuiRandoDifficulty.cs" />


### PR DESCRIPTION
- Refactored the generation process previously managed by button handlers in Oui code into a self-contained Builder class
- Updated Oui code to use the new Builder class
- Added ModInterop class to let other mods build a RandoSettings object without needing reflection or an assembly reference
- Added ModInterop class to let other mods initiate map generation without needing reflection or an assembly reference

These updates will be used by Head 2 Head to support randomizer races without relying on reflection