### PR TITLE
fix: phone placement fix v2

### DIFF
--- a/Randomizer/RandoLogic/RandoLogic.cs
+++ b/Randomizer/RandoLogic/RandoLogic.cs
@@ -659,9 +659,7 @@ namespace Celeste.Mod.Randomizer
                 var lines = new List<string>(regex.Split(lvl.Solids));
                 char at(int xx, int yy) => yy >= lines.Count ? '0' : xx >= lines[yy].Length ? '0' : lines[yy][xx];
                 var height = lines.Count;
-                var width = lines.Select(j => j.Length).Max();
-                IEnumerable<EntityData> spinners = lvl.Entities.Where(e => e.Name == "spinner" || e.Name == "spikesUp" ||
-                                                                           e.Name == "greenBlocks" || e.Name == "redBlocks" || e.Name == "yellowBlocks");
+                var width = lines.Select(j => j.Length).Max();                                                                           e.Name == "greenBlocks" || e.Name == "redBlocks" || e.Name == "yellowBlocks");
                 var found = false;
                 int x = 0, y = 0;
                 for (int i = 0; i < 20 && !found; i++)

--- a/Randomizer/RandoLogic/RandoLogic.cs
+++ b/Randomizer/RandoLogic/RandoLogic.cs
@@ -680,13 +680,15 @@ namespace Celeste.Mod.Randomizer
                             {
                                 y++;
                             }
-                            var safe = !spinners.Where(e =>
+                            var BehindEnt = lvl.Entities.Where(e =>
                             {
-                                var entWidth = e.Name != "spinner" ? e.Width : 8;
-                                var entHeight = e.Name != "spinner" && e.Name != "spikesUp" ? e.Height : 0;
-                                return e.Position.X / 8 + entWidth / 8 >= x && e.Position.X / 8 - 1 <= x && e.Position.Y / 8 + entHeight / 8 == y;
-                            }).Any();
+                                // entities that don't have these fields default to 0,
+                                // but to be certain the player can see the phone, check one tile over
+                                var entWidth = e.Width + 8;
+                                var entHeight = e.Height + 8;
 
+                                return e.Position.X / 8 + entWidth / 8 >= x && e.Position.X / 8 - 1 <= x && e.Position.Y / 8 + entHeight / 8 >= y && e.Position.Y / 8 - 1 <= y;
+                            }).Any();
                             var InsideRoof = lvl.FgDecals.Where(fg =>
                             {
                                 if (fg.Scale.X < 0)
@@ -695,7 +697,7 @@ namespace Celeste.Mod.Randomizer
                                 }
                                 return (fg.Position.X) / 8 <= x && (fg.Position.X + 8 * fg.Scale.X) / 8 >= x && (fg.Position.Y + 4) / 8 == y;
                             }).Any();
-                            if (at(x + 1, y - 1) == '0' && at(x + 1, y) != '0' &&  safe && !InsideRoof)
+                            if (at(x + 1, y - 1) == '0' && at(x + 1, y) != '0' && !BehindEnt && !InsideRoof)
                             {
                                 found = true;
                             }

--- a/Randomizer/RandoLogic/RandoLogic.cs
+++ b/Randomizer/RandoLogic/RandoLogic.cs
@@ -659,7 +659,7 @@ namespace Celeste.Mod.Randomizer
                 var lines = new List<string>(regex.Split(lvl.Solids));
                 char at(int xx, int yy) => yy >= lines.Count ? '0' : xx >= lines[yy].Length ? '0' : lines[yy][xx];
                 var height = lines.Count;
-                var width = lines.Select(j => j.Length).Max();                                                                           e.Name == "greenBlocks" || e.Name == "redBlocks" || e.Name == "yellowBlocks");
+                var width = lines.Select(j => j.Length).Max();
                 var found = false;
                 int x = 0, y = 0;
                 for (int i = 0; i < 20 && !found; i++)


### PR DESCRIPTION
After further investigation, if an entity does not have a height or width value, it defaults to 0. This should be generic enough to work in most instances. The only case I can find where it may not work is when placed under key doors (which is fine since they'll be unlocked in the run).