### PR TITLE
Add custom cassette music + improve build process

### DIFF
--- a/Randomizer/RandoLogic/RandoLogic.cs
+++ b/Randomizer/RandoLogic/RandoLogic.cs
@@ -133,6 +133,7 @@ namespace Celeste.Mod.Randomizer
         private LinkedMap Map;
         private RandoSettings Settings;
         private Capabilities Caps;
+        private List<String> CassetteSongs = new List<string>();
         public static Dictionary<string, string> RandomDialogMappings = new Dictionary<string, string>();
 
         private void ResetRooms()
@@ -256,28 +257,21 @@ namespace Celeste.Mod.Randomizer
 
         private string PickCassetteAudio()
         {
-            switch (this.Random.Next(8))
+            bool flag = false;
+            foreach (var area in AreaData.Areas)
             {
-                case 0:
-                    return SFX.cas_01_forsaken_city;
-                case 1:
-                    return SFX.cas_02_old_site;
-                case 2:
-                    return SFX.cas_03_resort;
-                case 3:
-                    return SFX.cas_04_cliffside;
-                case 4:
-                    return SFX.cas_05_mirror_temple;
-                case 5:
-                    return SFX.cas_06_reflection;
-                case 6:
-                    return SFX.cas_07_summit;
-                case 7:
-                default:
-                    return SFX.cas_08_core;
+                if (area.CassetteSong == null) continue;
+                if (area.CassetteSong == "event:/music/cassette/01_forsaken_city")
+                {
+                    if (flag) continue;
+                    flag = true;
+                }
+                CassetteSongs.Add(area.CassetteSong);
             }
+            int songCount = CassetteSongs.Count;
+            return CassetteSongs[this.Random.Next(songCount)];
         }
-
+        
         private string PickCompleteScreen()
         {
             uint seed = this.Settings.IntSeed;

--- a/Randomizer/RandoLogic/RandoLogic.cs
+++ b/Randomizer/RandoLogic/RandoLogic.cs
@@ -133,7 +133,7 @@ namespace Celeste.Mod.Randomizer
         private LinkedMap Map;
         private RandoSettings Settings;
         private Capabilities Caps;
-        private List<String> CassetteSongs = new List<string>();
+        private HashSet<String> CassetteSongs = new HashSet<string>();
         public static Dictionary<string, string> RandomDialogMappings = new Dictionary<string, string>();
 
         private void ResetRooms()
@@ -257,19 +257,13 @@ namespace Celeste.Mod.Randomizer
 
         private string PickCassetteAudio()
         {
-            bool flag = false;
             foreach (var area in AreaData.Areas)
             {
                 if (area.CassetteSong == null) continue;
-                if (area.CassetteSong == "event:/music/cassette/01_forsaken_city")
-                {
-                    if (flag) continue;
-                    flag = true;
-                }
                 CassetteSongs.Add(area.CassetteSong);
             }
             int songCount = CassetteSongs.Count;
-            return CassetteSongs[this.Random.Next(songCount)];
+            return CassetteSongs.ElementAt(this.Random.Next(songCount));
         }
         
         private string PickCompleteScreen()

--- a/Randomizer/Randomizer.csproj
+++ b/Randomizer/Randomizer.csproj
@@ -33,6 +33,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Celeste">
       <HintPath>..\packages\Celeste.exe</HintPath>

--- a/bundle.sh
+++ b/bundle.sh
@@ -4,6 +4,7 @@ dotnet build
 VERSION=$(cat Randomizer/everest.yaml | grep '^  Version' | cut -d' ' -f 4)
 FILENAME=dist/Randomizer_${VERSION}${2}.zip
 rm -f $FILENAME
+mkdir -p dist
 cd Randomizer/bin/${1-Debug}
 zip -r ../../../${FILENAME} *
 echo Finished in ${FILENAME}


### PR DESCRIPTION
Added a way to have custom cassette music without additional config items(closes #125) The only issue I can see is that this might lead to duplicate songs? 

Also, added a suppressor for building warnings and changes the script to make the 'dist' directory if needed. Only other change I wanted to add on was stub dlls as mentioned in #174 but I am currently having issues doing so. 