### PR TITLE
fix the cassette rooms stopped working in some seeded.

### DIFF
--- a/Randomizer/RandoLogic/RandoLogic.cs
+++ b/Randomizer/RandoLogic/RandoLogic.cs
@@ -8,6 +8,8 @@ using System.Text.RegularExpressions;
 using Microsoft.Xna.Framework;
 using Monocle;
 using MonoMod.Utils;
+using FMOD;
+using FMOD.Studio;
 
 namespace Celeste.Mod.Randomizer
 {
@@ -101,6 +103,11 @@ namespace Celeste.Mod.Randomizer
                     newArea.Wipe = r.PickWipe();
                     newArea.CompleteScreenName = r.PickCompleteScreen();
                     newArea.CassetteSong = r.PickCassetteAudio();
+                    if (Audio.CreateInstance(newArea.CassetteSong, null) is null) {
+                        // Invalid cassette song? ugh
+                        newArea.CassetteSong = "event:/music/cassette/01_forsaken_city";
+                    }
+
                     newArea.Mode[0].AudioState = r.PickAudioState();
                     if (settings.RandomColors)
                     {


### PR DESCRIPTION
The problem is that when a seeded map happens to have invalid cassette song from the metadata settings of a certain map (`monikadsidespack\2\6-TempleBeta` with `cas_05_mirror_temple` not `event:/music/cassette/05_mirror_temple`).